### PR TITLE
Added an 'Open JSON file... ⌘O' MenuBar item

### DIFF
--- a/app/js/Editor.js
+++ b/app/js/Editor.js
@@ -45,7 +45,8 @@ const defaultEditorOptions = {
 const defaultFormatOptions = {
   indent_size: 2,
   indent_char: ' ',
-  preserve_newlines: false
+  preserve_newlines: false,
+  brace_style: 'expand',
 }
 
 /**

--- a/app/js/system/MainMenu.js
+++ b/app/js/system/MainMenu.js
@@ -4,9 +4,11 @@
  * Dependencies
  */
 
+const fs = require('fs')
+
 const { remote } = require('electron')
 
-const { Menu } = remote
+const { Menu, BrowserWindow, dialog } = remote
 
 class MainMenu {
 
@@ -32,6 +34,20 @@ class MainMenu {
 
   createTemplate() {
     const template = [{
+      label: 'File',
+      submenu: [{
+        label: 'Open JSON file...',
+        accelerator: 'CommandOrControl+O',
+        click: () => {
+          dialog.showOpenDialog(
+            BrowserWindow.getFocusedWindow()||BrowserWindow.getAllWindows()[0],
+            {filters:[{name: 'JSON Files', extensions: ['json']}, {name: 'All Files', extensions: ['*']}]},
+            filePaths => { 
+              window.app=this.app
+              this.app.getCurrentPage().editor.editor.setValue(fs.readFileSync(filePaths[0], 'utf8')) }
+          )
+        }
+      }]},{
       label: 'Edit',
       submenu: [{
         role: 'undo'
@@ -126,7 +142,7 @@ class MainMenu {
       })
 
         // Edit menu.
-      template[1].submenu.push({
+      template[2].submenu.push({
         type: 'separator'
       }, {
         label: 'Speech',
@@ -138,7 +154,7 @@ class MainMenu {
       })
 
         // Window menu.
-      template[3].submenu = [{
+      template[4].submenu = [{
         label: 'Close',
         accelerator: 'CmdOrCtrl+W',
         role: 'close'

--- a/app/js/system/MainMenu.js
+++ b/app/js/system/MainMenu.js
@@ -67,11 +67,13 @@ class MainMenu {
         type: 'separator'
       }, {
         label: 'Format',
+        accelerator: 'CommandOrControl+Shift+F',
         click: () => {
           this.app.getCurrentPage().editor.format()
         }
       }, {
         label: 'Minify',
+        accelerator: 'CommandOrControl+Shift+M',
         click: () => {
           this.app.getCurrentPage().editor.minify()
         }


### PR DESCRIPTION
This allows users to open a file using `⌘O`/`CTRL+O` to open a file from a user's file directory, it replaces the whole editor view, which I feel is appropriate and expected behaviour.

There's no extra non-Node or non-Electron modules, and a lot less CodeMirror wrangling than I had anticipated.