### PR TITLE
Windows node-jq and jq fix

### DIFF
--- a/app/js/Editor.js
+++ b/app/js/Editor.js
@@ -69,9 +69,8 @@ class Editor extends EventEmitter {
     this.filter = filter
 
     // Path to store data file so it can be read for jq (required for large input)
-    this.tmp = path.resolve(__dirname, '..', 'tmp', 'data.json')
-    // Absolute path is too long to be parsed by jq in Windows (jq bug)
-    this.tmpRelative = path.join('app', 'tmp', 'data.json')
+    // NOTE: the absolute path is too long to be parsed by jq in Windows (jq bug)
+    this.tmp = path.join('app', 'tmp', 'data.json')
 
     // Set js-beautify format options
     this.formatOptions = defaultFormatOptions
@@ -251,7 +250,7 @@ class Editor extends EventEmitter {
       fs.writeFileSync(this.tmp, JSON.stringify(this.data))
 
       // If JavaScript filter fails, run through jq
-      jq.run(filter, this.tmpRelative, {
+      jq.run(filter, this.tmp, {
         input: 'file',
         output: 'json'
       }).then((result) => {

--- a/app/js/Editor.js
+++ b/app/js/Editor.js
@@ -70,6 +70,8 @@ class Editor extends EventEmitter {
 
     // Path to store data file so it can be read for jq (required for large input)
     this.tmp = path.resolve(__dirname, '..', 'tmp', 'data.json')
+    // Absolute path is too long to be parsed by jq in Windows (jq bug)
+    this.tmpRelative = path.join('app', 'tmp', 'data.json')
 
     // Set js-beautify format options
     this.formatOptions = defaultFormatOptions
@@ -249,7 +251,7 @@ class Editor extends EventEmitter {
       fs.writeFileSync(this.tmp, JSON.stringify(this.data))
 
       // If JavaScript filter fails, run through jq
-      jq.run(filter, this.tmp, {
+      jq.run(filter, this.tmpRelative, {
         input: 'file',
         output: 'json'
       }).then((result) => {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jsonlint": "^1.6.2",
     "menu": "^0.2.5",
     "mkdirp": "^0.5.1",
-    "node-jq": "^0.4.0",
+    "node-jq": ">=0.5.0",
     "proxyquire": "^1.7.10",
     "superagent": "^3.1.0"
   },


### PR DESCRIPTION
- `node-jq` v.0.5.0 now supports windows
- `jq` has a limit to the length of the arguments, I changed the path of the tmp file from absolute to relative (= smaller) and it works.

This pr resolves all jq issues in Windows (#56 and others?)